### PR TITLE
Enables pluto tiling for simple cases

### DIFF
--- a/lib/Transforms/PlutoTransform.cc
+++ b/lib/Transforms/PlutoTransform.cc
@@ -36,6 +36,19 @@ using namespace mlir;
 using namespace llvm;
 using namespace polymer;
 
+/// Insert value mapping into the given mapping object based on the provided src
+/// and dst symbol tables.
+static void updateValueMapping(OslSymbolTable &srcTable,
+                               OslSymbolTable &dstTable,
+                               BlockAndValueMapping &mapping) {
+  // TODO: check the symbol compatibility between srcTable and dstTable.
+  SmallVector<StringRef, 8> symbols;
+  srcTable.getValueSymbols(symbols);
+
+  for (auto sym : symbols)
+    mapping.map(srcTable.getValue(sym), dstTable.getValue(sym));
+}
+
 namespace {
 
 struct PlutoTransform : public OpConversionPattern<mlir::FuncOp> {
@@ -60,7 +73,7 @@ struct PlutoTransform : public OpConversionPattern<mlir::FuncOp> {
     pluto_tile(prog);
 
     pluto_populate_scop(scop->get(), prog, context);
-    osl_scop_print(stdout, scop->get());
+    // osl_scop_print(stdout, scop->get());
 
     auto moduleOp = dyn_cast<mlir::ModuleOp>(funcOp.getParentOp());
 
@@ -68,7 +81,31 @@ struct PlutoTransform : public OpConversionPattern<mlir::FuncOp> {
     auto newFuncOp = createFuncOpFromOpenScop(std::move(scop), moduleOp,
                                               dstTable, rewriter.getContext());
 
-    rewriter.updateRootInPlace(funcOp, []() {});
+    BlockAndValueMapping mapping;
+    // TODO: refactorize this function and the following logic.
+    updateValueMapping(srcTable, dstTable, mapping);
+
+    SmallVector<StringRef, 8> stmtSymbols;
+    srcTable.getOpSetSymbols(stmtSymbols);
+    for (auto stmtSym : stmtSymbols) {
+      // The operation to be cloned.
+      auto srcOpSet = srcTable.getOpSet(stmtSym);
+      // The clone destination.
+      auto dstOpSet = dstTable.getOpSet(stmtSym);
+      auto dstOp = dstOpSet.get(0);
+
+      rewriter.setInsertionPoint(dstOp);
+
+      for (unsigned i = 0, e = srcOpSet.size(); i < e; i++)
+        rewriter.clone(*(srcOpSet.get(e - i - 1)), mapping);
+
+      // rewriter.setInsertionPoint(dstOp);
+      // rewriter.clone(*srcOp, mapping);
+      rewriter.eraseOp(dstOp);
+      rewriter.eraseOp(dstOpSet.get(1));
+    }
+
+    rewriter.eraseOp(funcOp);
 
     pluto_context_free(context);
     return success();

--- a/test/polymer-opt/PlutoTransform/arith.mlir
+++ b/test/polymer-opt/PlutoTransform/arith.mlir
@@ -1,0 +1,45 @@
+// RUN: polymer-opt %s -pluto-opt | FileCheck %s
+
+func @arith() {
+  %A = alloc() : memref<64xf32>
+  %B = alloc() : memref<64xf32>
+  %C = alloc() : memref<64xf32>
+  %D = alloc() : memref<64xf32>
+
+  affine.for %i = 0 to 64 {
+    %0 = affine.load %A[%i] : memref<64xf32>
+    %1 = affine.load %B[%i] : memref<64xf32>
+    %2 = addf %0, %1 : f32
+    %3 = mulf %0, %2 : f32
+    affine.store %2, %C[%i] : memref<64xf32>
+    affine.store %3, %D[%i] : memref<64xf32>
+  }
+  
+  return
+}
+
+// CHECK: #map0 = affine_map<(d0) -> (d0)>
+// CHECK: #map1 = affine_map<(d0) -> (d0 * 32)>
+// CHECK: #map2 = affine_map<(d0) -> (d0 * 32 + 31)>
+// CHECK: #map3 = affine_map<() -> (0)>
+// CHECK: #map4 = affine_map<() -> (1)>
+//
+//
+// CHECK: module {
+// CHECK:   func @main(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<?xf32>, %arg3: memref<?xf32>) {
+// CHECK:     affine.for %arg4 = 0 to 1 {
+// CHECK:       affine.for %arg5 = #map1(%arg4) to #map2(%arg4) {
+// CHECK:         %0 = affine.load %arg2[%arg5] : memref<?xf32>
+// CHECK:         %1 = affine.load %arg1[%arg5] : memref<?xf32>
+// CHECK:         %2 = addf %1, %0 : f32
+// CHECK:         affine.store %2, %arg0[%arg5] : memref<?xf32>
+// CHECK:         %3 = affine.load %arg2[%arg5] : memref<?xf32>
+// CHECK:         %4 = addf %1, %3 : f32
+// CHECK:         %5 = affine.load %arg1[%arg5] : memref<?xf32>
+// CHECK:         %6 = mulf %5, %4 : f32
+// CHECK:         affine.store %6, %arg3[%arg5] : memref<?xf32>
+// CHECK:       }
+// CHECK:     }
+// CHECK:     return
+// CHECK:   }
+// CHECK: }

--- a/test/polymer-opt/PlutoTransform/load-store.mlir
+++ b/test/polymer-opt/PlutoTransform/load-store.mlir
@@ -1,3 +1,4 @@
+// RUN: polymer-opt %s -pluto-opt | FileCheck %s
 func @load_store() -> () {
   %A = alloc() : memref<64xf32>
   affine.for %i = 0 to 64 {
@@ -6,3 +7,23 @@ func @load_store() -> () {
   }
   return
 }
+
+
+// CHECK: #map0 = affine_map<(d0) -> (d0)>
+// CHECK: #map1 = affine_map<(d0) -> (d0 * 32)>
+// CHECK: #map2 = affine_map<(d0) -> (d0 * 32 + 31)>
+// CHECK: #map3 = affine_map<() -> (0)>
+// CHECK: #map4 = affine_map<() -> (1)>
+//
+//
+// CHECK: module {
+// CHECK:   func @main(%arg0: memref<?xf32>) {
+// CHECK:     affine.for %arg1 = 0 to 1 {
+// CHECK:       affine.for %arg2 = #map1(%arg1) to #map2(%arg1) {
+// CHECK:         %0 = affine.load %arg0[%arg2] : memref<?xf32>
+// CHECK:         affine.store %0, %arg0[%arg2] : memref<?xf32>
+// CHECK:       }
+// CHECK:     }
+// CHECK:     return
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
This PR enables simple tiling supported by PLUTO. The major difference is the handling of iterators in statement `<body>` that becomes different to the ones in `<scatnames>` after PLUTO transformation. We use a simple HACK, which can work for simple cases. We will test more generic situation in the future.