### PR TITLE
Fixed flatExprs -> access relation & added matmul.

### DIFF
--- a/test/polymer-opt/InvariantScopTransform/matmul.mlir
+++ b/test/polymer-opt/InvariantScopTransform/matmul.mlir
@@ -1,0 +1,45 @@
+// RUN: polymer-opt %s -invariant-scop | FileCheck %s
+
+func @matmul() {
+  %A = alloc() : memref<64x64xf32>
+  %B = alloc() : memref<64x64xf32>
+  %C = alloc() : memref<64x64xf32>
+
+  affine.for %i = 0 to 64 {
+    affine.for %j = 0 to 64 {
+      affine.for %k = 0 to 64 {
+        %0 = affine.load %A[%i, %k] : memref<64x64xf32>
+        %1 = affine.load %B[%k, %j] : memref<64x64xf32>
+        %2 = mulf %0, %1 : f32
+        %3 = affine.load %C[%i, %j] : memref<64x64xf32>
+        %4 = addf %2, %3 : f32
+        affine.store %4, %C[%i, %j] : memref<64x64xf32>
+      }
+    }
+  }
+
+  return
+}
+
+// CHECK: #map0 = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK: #map1 = affine_map<() -> (0)>
+// CHECK: #map2 = affine_map<() -> (63)>
+//
+//
+// CHECK: module {
+// CHECK:   func @main(%arg0: memref<?x?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32>) {
+// CHECK:     affine.for %arg3 = 0 to 63 {
+// CHECK:       affine.for %arg4 = 0 to 63 {
+// CHECK:         affine.for %arg5 = 0 to 63 {
+// CHECK:           %0 = affine.load %arg0[%arg3, %arg4] : memref<?x?xf32>
+// CHECK:           %1 = affine.load %arg2[%arg5, %arg4] : memref<?x?xf32>
+// CHECK:           %2 = affine.load %arg1[%arg3, %arg5] : memref<?x?xf32>
+// CHECK:           %3 = mulf %2, %1 : f32
+// CHECK:           %4 = addf %3, %0 : f32
+// CHECK:           affine.store %4, %arg0[%arg3, %arg4] : memref<?x?xf32>
+// CHECK:         }
+// CHECK:       }
+// CHECK:     }
+// CHECK:     return
+// CHECK:   }
+// CHECK: }

--- a/test/polymer-opt/PlutoTransform/matmul.mlir
+++ b/test/polymer-opt/PlutoTransform/matmul.mlir
@@ -1,0 +1,20 @@
+func @matmul() {
+  %A = alloc() : memref<64x64xf32>
+  %B = alloc() : memref<64x64xf32>
+  %C = alloc() : memref<64x64xf32>
+
+  affine.for %i = 0 to 64 {
+    affine.for %j = 0 to 64 {
+      affine.for %k = 0 to 64 {
+        %0 = affine.load %A[%i, %k] : memref<64x64xf32>
+        %1 = affine.load %B[%k, %j] : memref<64x64xf32>
+        %2 = mulf %0, %1 : f32
+        %3 = affine.load %C[%i, %j] : memref<64x64xf32>
+        %4 = addf %2, %3 : f32
+        affine.store %4, %C[%i, %j] : memref<64x64xf32>
+      }
+    }
+  }
+
+  return
+}

--- a/test/polymer-translate/export-scop/matmul.mlir
+++ b/test/polymer-translate/export-scop/matmul.mlir
@@ -1,0 +1,125 @@
+// RUN: polymer-translate %s -export-scop | FileCheck %s
+
+func @matmul() {
+  %A = alloc() : memref<64x64xf32>
+  %B = alloc() : memref<64x64xf32>
+  %C = alloc() : memref<64x64xf32>
+
+  affine.for %i = 0 to 64 {
+    affine.for %j = 0 to 64 {
+      affine.for %k = 0 to 64 {
+        %0 = affine.load %A[%i, %k] : memref<64x64xf32>
+        %1 = affine.load %B[%k, %j] : memref<64x64xf32>
+        %2 = mulf %0, %1 : f32
+        %3 = affine.load %C[%i, %j] : memref<64x64xf32>
+        %4 = addf %2, %3 : f32
+        affine.store %4, %C[%i, %j] : memref<64x64xf32>
+      }
+    }
+  }
+
+  return
+}
+
+
+// CHECK: <OpenScop>
+//
+// CHECK: # =============================================== Global
+// CHECK: # Language
+// CHECK: C
+//
+// CHECK: # Context
+// CHECK: CONTEXT
+// CHECK: 0 2 0 0 0 0
+//
+// CHECK: # Parameters are not provided
+// CHECK: 0
+//
+//
+// CHECK: # Number of statements
+// CHECK: 1
+//
+// CHECK: # =============================================== Statement 1
+// CHECK: # Number of relations describing the statement:
+// CHECK: 6
+//
+// CHECK: # ----------------------------------------------  1.1 Domain
+// CHECK: DOMAIN
+// CHECK: 6 5 3 0 0 0
+// CHECK: # e/i| i0   i1   i2 |  1  
+// CHECK:    1    1    0    0    0    ## i0 >= 0
+// CHECK:    1   -1    0    0   63    ## -i0+63 >= 0
+// CHECK:    1    0    1    0    0    ## i1 >= 0
+// CHECK:    1    0   -1    0   63    ## -i1+63 >= 0
+// CHECK:    1    0    0    1    0    ## i2 >= 0
+// CHECK:    1    0    0   -1   63    ## -i2+63 >= 0
+//
+// CHECK: # ----------------------------------------------  1.2 Scattering
+// CHECK: SCATTERING
+// CHECK: 7 12 7 3 0 0
+// CHECK: # e/i| c1   c2   c3   c4   c5   c6   c7 | i0   i1   i2 |  1  
+// CHECK:    0   -1    0    0    0    0    0    0    0    0    0    0    ## c1 == 0
+// CHECK:    0    0   -1    0    0    0    0    0    1    0    0    0    ## c2 == i0
+// CHECK:    0    0    0   -1    0    0    0    0    0    0    0    0    ## c3 == 0
+// CHECK:    0    0    0    0   -1    0    0    0    0    1    0    0    ## c4 == i1
+// CHECK:    0    0    0    0    0   -1    0    0    0    0    0    0    ## c5 == 0
+// CHECK:    0    0    0    0    0    0   -1    0    0    0    1    0    ## c6 == i2
+// CHECK:    0    0    0    0    0    0    0   -1    0    0    0    0    ## c7 == 0
+//
+// CHECK: # ----------------------------------------------  1.3 Access
+// CHECK: WRITE
+// CHECK: 3 8 3 3 0 0
+// CHECK: # e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+// CHECK:    0   -1    0    0    0    0    0    1    ## Arr == A1
+// CHECK:    0    0   -1    0    1    0    0    0    ## [1] == i0
+// CHECK:    0    0    0   -1    0    1    0    0    ## [2] == i1
+//
+// CHECK: READ
+// CHECK: 3 8 3 3 0 0
+// CHECK: # e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+// CHECK:    0   -1    0    0    0    0    0    2    ## Arr == A2
+// CHECK:    0    0   -1    0    1    0    0    0    ## [1] == i0
+// CHECK:    0    0    0   -1    0    0    1    0    ## [2] == i2
+//
+// CHECK: READ
+// CHECK: 3 8 3 3 0 0
+// CHECK: # e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+// CHECK:    0   -1    0    0    0    0    0    3    ## Arr == A3
+// CHECK:    0    0   -1    0    0    0    1    0    ## [1] == i2
+// CHECK:    0    0    0   -1    0    1    0    0    ## [2] == i1
+//
+// CHECK: READ
+// CHECK: 3 8 3 3 0 0
+// CHECK: # e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+// CHECK:    0   -1    0    0    0    0    0    1    ## Arr == A1
+// CHECK:    0    0   -1    0    1    0    0    0    ## [1] == i0
+// CHECK:    0    0    0   -1    0    1    0    0    ## [2] == i1
+//
+// CHECK: # ----------------------------------------------  1.4 Statement Extensions
+// CHECK: # Number of Statement Extensions
+// CHECK: 1
+// CHECK: <body>
+// CHECK: # Number of original iterators
+// CHECK: 3
+// CHECK: # List of original iterators
+// CHECK: i0 i1 i2
+// CHECK: # Statement body expression
+// CHECK: S0(A1, 2, A2, 2, A3, 2, A1, 2, i0, i1, i2)
+// CHECK: </body>
+
+// Won't check the extension generation for this case.
+// # =============================================== Extensions
+// <arrays>
+// # Number of arrays
+// 3
+// # Mapping array-identifiers/array-names
+// 2 A2
+// 3 A3
+// 1 A1
+// </arrays>
+//
+// <scatnames>
+// c0 i0 c2 i1 c4 i2 c6
+// </scatnames>
+//
+// </OpenScop>

--- a/test/polymer-translate/export-scop/transpose.mlir
+++ b/test/polymer-translate/export-scop/transpose.mlir
@@ -85,8 +85,8 @@ func @transpose(%A : memref<?x?xf32>) -> () {
 // CHECK: 3 9 3 2 0 2
 // CHECK: # e/i| Arr  [1]  [2]| i0   i1 | P0   P1 |  1  
 // CHECK:    0   -1    0    0    0    0    0    0    1    ## Arr == A1
-// CHECK:    0    0   -1    0    1    0    0    0    0    ## [1] == i0
-// CHECK:    0    0    0   -1    0    1    0    0    0    ## [2] == i1
+// CHECK:    0    0   -1    0    0    1    0    0    0    ## [1] == i1
+// CHECK:    0    0    0   -1    1    0    0    0    0    ## [2] == i0
 //
 // CHECK: READ
 // CHECK: 3 9 3 2 0 2

--- a/test/polymer-translate/import-scop/matmul.scop
+++ b/test/polymer-translate/import-scop/matmul.scop
@@ -1,0 +1,121 @@
+// RUN: polymer-translate %s -import-scop | FileCheck %s
+
+<OpenScop>
+
+# =============================================== Global
+# Language
+C
+
+# Context
+CONTEXT
+0 2 0 0 0 0
+
+# Parameters are not provided
+0
+
+
+# Number of statements
+1
+
+# =============================================== Statement 1
+# Number of relations describing the statement:
+6
+
+# ----------------------------------------------  1.1 Domain
+DOMAIN
+6 5 3 0 0 0
+# e/i| i0   i1   i2 |  1  
+   1    1    0    0    0    ## i0 >= 0
+   1   -1    0    0   63    ## -i0+63 >= 0
+   1    0    1    0    0    ## i1 >= 0
+   1    0   -1    0   63    ## -i1+63 >= 0
+   1    0    0    1    0    ## i2 >= 0
+   1    0    0   -1   63    ## -i2+63 >= 0
+
+# ----------------------------------------------  1.2 Scattering
+SCATTERING
+7 12 7 3 0 0
+# e/i| c1   c2   c3   c4   c5   c6   c7 | i0   i1   i2 |  1  
+   0   -1    0    0    0    0    0    0    0    0    0    0    ## c1 == 0
+   0    0   -1    0    0    0    0    0    1    0    0    0    ## c2 == i0
+   0    0    0   -1    0    0    0    0    0    0    0    0    ## c3 == 0
+   0    0    0    0   -1    0    0    0    0    1    0    0    ## c4 == i1
+   0    0    0    0    0   -1    0    0    0    0    0    0    ## c5 == 0
+   0    0    0    0    0    0   -1    0    0    0    1    0    ## c6 == i2
+   0    0    0    0    0    0    0   -1    0    0    0    0    ## c7 == 0
+
+# ----------------------------------------------  1.3 Access
+WRITE
+3 8 3 3 0 0
+# e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+   0   -1    0    0    0    0    0    1    ## Arr == A1
+   0    0   -1    0    1    0    0    0    ## [1] == i0
+   0    0    0   -1    0    1    0    0    ## [2] == i1
+
+READ
+3 8 3 3 0 0
+# e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+   0   -1    0    0    0    0    0    2    ## Arr == A2
+   0    0   -1    0    1    0    0    0    ## [1] == i0
+   0    0    0   -1    0    0    1    0    ## [2] == i2
+
+READ
+3 8 3 3 0 0
+# e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+   0   -1    0    0    0    0    0    3    ## Arr == A3
+   0    0   -1    0    0    0    1    0    ## [1] == i2
+   0    0    0   -1    0    1    0    0    ## [2] == i1
+
+READ
+3 8 3 3 0 0
+# e/i| Arr  [1]  [2]| i0   i1   i2 |  1  
+   0   -1    0    0    0    0    0    1    ## Arr == A1
+   0    0   -1    0    1    0    0    0    ## [1] == i0
+   0    0    0   -1    0    1    0    0    ## [2] == i1
+
+# ----------------------------------------------  1.4 Statement Extensions
+# Number of Statement Extensions
+1
+<body>
+# Number of original iterators
+3
+# List of original iterators
+i0 i1 i2
+# Statement body expression
+S0(A1, 2, A2, 2, A3, 2, A1, 2, i0, i1, i2)
+</body>
+
+# =============================================== Extensions
+<arrays>
+# Number of arrays
+3
+# Mapping array-identifiers/array-names
+2 A2
+3 A3
+1 A1
+</arrays>
+
+<scatnames>
+c0 i0 c2 i1 c4 i2 c6
+</scatnames>
+
+</OpenScop>
+
+
+// CHECK: #map0 = affine_map<() -> (0)>
+// CHECK: #map1 = affine_map<() -> (63)>
+//
+//
+// CHECK: module {
+// CHECK:   func @main(%arg0: memref<?x?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32>) {
+// CHECK:     affine.for %arg3 = 0 to 63 {
+// CHECK:       affine.for %arg4 = 0 to 63 {
+// CHECK:         affine.for %arg5 = 0 to 63 {
+// CHECK:           call @S0(%arg0, %arg1, %arg2, %arg0, %arg3, %arg4, %arg5) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, index, index, index) -> ()
+// CHECK:         }
+// CHECK:       }
+// CHECK:     }
+// CHECK:     return
+// CHECK:   }
+// CHECK:   func @S0(memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, index, index, index)
+// CHECK: } 


### PR DESCRIPTION
This PR fixes an existing problem in the `addAccessToScop` function. The previous mapping was wrong. We should consider the case that the flatExprs may contain less & unordered columns than the access relation.

This PR also adds a new matmul test case.