### PR TITLE
Added extract-scop-stmt pass

### DIFF
--- a/include/polymer/Transforms/ExtractScopStmt.h
+++ b/include/polymer/Transforms/ExtractScopStmt.h
@@ -1,0 +1,17 @@
+//===- ExtractScopStmt.h - Extract scop stmt to func ------------------C++-===//
+//
+// This file declares the transformation that extracts scop statements into MLIR
+// functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef POLYMER_TRANSFORMS_EXTRACTSCOPSTMT_H
+#define POLYMER_TRANSFORMS_EXTRACTSCOPSTMT_H
+
+namespace polymer {
+
+void registerExtractScopStmtPass();
+
+}
+
+#endif

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(PolymerTransforms
   InvariantScopTransform.cc
   PlutoTransform.cc
+  ExtractScopStmt.cc
 
   ADDITIONAL_HEADER_DIRS
   "${POLYMER_MAIN_INCLUDE_DIR}/polymer/Transforms"

--- a/lib/Transforms/ExtractScopStmt.cc
+++ b/lib/Transforms/ExtractScopStmt.cc
@@ -136,6 +136,10 @@ static mlir::FuncOp createCallee(StringRef calleeName,
 
   // Terminator
   b.create<mlir::ReturnOp>(callee.getLoc());
+  // Set the scop_stmt attribute for identification at a later stage.
+  // TODO: in the future maybe we could create a customized dialect, e.g., Scop,
+  // that contains scop stmt FuncOp, e.g., ScopStmtOp.
+  callee.setAttr("scop.stmt", b.getUnitAttr());
 
   return callee;
 }

--- a/lib/Transforms/ExtractScopStmt.cc
+++ b/lib/Transforms/ExtractScopStmt.cc
@@ -1,0 +1,224 @@
+//===- ExtractScopStmt.cc - Extract scop stmt to func -----------------C++-===//
+//
+// This file implements the transformation that extracts scop statements into
+// MLIR functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "polymer/Transforms/ExtractScopStmt.h"
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Function.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/Utils.h"
+
+#include "llvm/ADT/SetVector.h"
+
+using namespace mlir;
+using namespace llvm;
+using namespace polymer;
+
+using CalleeName = SmallString<16>;
+
+/// Discover the operations that have memory write effects.
+/// TODO: use MemoryEffects to properly detect ops that has memory write side
+/// effects.
+static void discoverMemWriteOps(mlir::FuncOp f,
+                                SmallVectorImpl<Operation *> &ops) {
+  f.getOperation()->walk([&](Operation *op) {
+    if (isa<mlir::AffineWriteOpInterface>(op))
+      ops.push_back(op);
+  });
+}
+
+/// Recursively get all the ops belongs to a statement starting from the given
+/// operation. The sequence of the operations in defOps will be reversed,
+/// depth-first, starting from op. Note that the initial op will be placed in
+/// the resulting ops as well.
+static void getScopStmtOps(Operation *op, SetVector<Operation *> &ops,
+                           SetVector<mlir::Value> &args) {
+  // Base case.
+  if (!op)
+    return;
+
+  // Types of operation that terminates the recusion:
+  // Memory allocation ops will be omitted, reaching them means the end of
+  // recursion. We will take care of these ops in other passes. The result of
+  // these allocation op, i.e., memref, will be
+  if (isa<mlir::AllocaOp, mlir::AllocOp>(op)) {
+    for (mlir::Value result : op->getResults())
+      args.insert(result);
+    return;
+  }
+
+  // TODO: checks if op has side effects.
+
+  // Keep the op in the given set.
+  ops.insert(op);
+
+  // Recursively visit other defining ops that are not in ops.
+  for (auto operand : op->getOperands()) {
+    // Stop the recursion at block arguments, e.g., loop IVs, external
+    // arguments, and insert it into args.
+    if (operand.isa<BlockArgument>()) {
+      args.insert(operand);
+    } else {
+      auto defOp = operand.getDefiningOp();
+      if (!ops.contains(defOp))
+        getScopStmtOps(defOp, ops, args);
+    }
+  }
+
+  return;
+}
+
+static void getCalleeName(unsigned calleeId, CalleeName &calleeName,
+                          char prefix = 'S') {
+  calleeName.push_back(prefix);
+  calleeName += std::to_string(calleeId);
+}
+
+/// Create the function definition that contains all the operations that belong
+/// to a Scop statement. The function name will be the given calleeName, its
+/// contents will be ops, and its type is depend on the given list of args. This
+/// callee function has a single block in it, and it has no returned value. The
+/// callee will be inserted at the end of the whole module.
+static mlir::FuncOp createCallee(StringRef calleeName,
+                                 SetVector<Operation *> &ops,
+                                 SetVector<mlir::Value> &args, mlir::ModuleOp m,
+                                 Operation *writeOp, OpBuilder &b) {
+  assert(ops.contains(writeOp) && "writeOp should be a member in ops.");
+
+  unsigned numArgs = args.size();
+  unsigned numOps = ops.size();
+
+  // Get a list of types of all function arguments, and use it to create the
+  // function type.
+  SmallVector<mlir::Type, 8> argTypes;
+  for (mlir::Value arg : args)
+    argTypes.push_back(arg.getType());
+  mlir::FunctionType calleeType = b.getFunctionType(argTypes, llvm::None);
+
+  // Insert the new callee before the end of the module body.
+  OpBuilder::InsertionGuard guard(b);
+  b.setInsertionPoint(m.getBody(), std::prev(m.getBody()->end()));
+
+  // Create the callee. Its loc is determined by the writeOp.
+  mlir::FuncOp callee =
+      b.create<mlir::FuncOp>(writeOp->getLoc(), calleeName, calleeType);
+  mlir::Block *entryBlock = callee.addEntryBlock();
+  b.setInsertionPointToStart(entryBlock);
+
+  // Create the mapping from the args to the newly created BlockArguments, to
+  // replace the uses of the values in the original function to the newly
+  // declared entryBlock's input.
+  BlockAndValueMapping mapping;
+  for (unsigned i = 0; i < numArgs; i++)
+    mapping.map(args[i], entryBlock->getArgument(i));
+
+  // Clone the operations into the new callee function. In case they are not in
+  // the correct order, we sort them topologically beforehand.
+  SetVector<Operation *> sortedOps = topologicalSort(ops);
+  for (unsigned i = 0; i < numOps; i++)
+    b.clone(*sortedOps[i], mapping);
+
+  // Terminator
+  b.create<mlir::ReturnOp>(b.getUnknownLoc());
+
+  return callee;
+}
+
+/// Create a caller to the callee right after the writeOp, which will be removed
+/// later.
+static mlir::CallOp createCaller(mlir::FuncOp callee,
+                                 SetVector<mlir::Value> &args,
+                                 Operation *writeOp, OpBuilder &b) {
+  OpBuilder::InsertionGuard guard(b);
+  b.setInsertionPointAfter(writeOp);
+
+  return b.create<mlir::CallOp>(writeOp->getLoc(), callee, args.takeVector());
+}
+
+/// Remove those ops that are already in the callee, and not have uses by other
+/// ops. We will first sort these ops topologically, and then remove them in a
+/// reversed order.
+static void removeExtractedOps(SetVector<Operation *> &opsToRemove) {
+  opsToRemove = topologicalSort(opsToRemove);
+  unsigned numOpsToRemove = opsToRemove.size();
+
+  for (unsigned i = 0; i < numOpsToRemove; i++) {
+    Operation *op = opsToRemove[numOpsToRemove - i - 1];
+    // TODO: need to check if this should be allowed to happen.
+    if (op->getUses().empty())
+      op->erase();
+  }
+}
+
+/// The main function that extracts scop statements as functions.
+static void extractScopStmt(mlir::FuncOp f, OpBuilder &b) {
+  // First discover those write ops that will be the "terminator" of each scop
+  // statement in the given function.
+  SmallVector<Operation *, 8> writeOps;
+  discoverMemWriteOps(f, writeOps);
+
+  unsigned numWriteOps = writeOps.size();
+
+  SetVector<Operation *> ops;
+  SetVector<mlir::Value> args;
+  SetVector<Operation *> opsToRemove;
+
+  // Use the top-level module to locate places for new functions insertion.
+  mlir::ModuleOp m = dyn_cast<mlir::ModuleOp>(f.getParentOp());
+  // A writeOp will result in a new caller/callee pair.
+  for (unsigned i = 0; i < numWriteOps; i++) {
+    ops.clear();
+    // Get all the ops inside a statement that corresponds to the current write
+    // operation.
+    Operation *writeOp = writeOps[i];
+    getScopStmtOps(writeOp, ops, args);
+
+    // Get the name of the callee. Should be in the form of "S<id>".
+    CalleeName calleeName;
+    getCalleeName(i, calleeName);
+
+    // Create the callee.
+    mlir::FuncOp callee = createCallee(calleeName, ops, args, m, writeOp, b);
+    // Create the caller.
+    mlir::CallOp caller = createCaller(callee, args, writeOp, b);
+
+    // All the ops that have been placed in the callee should be removed.
+    opsToRemove.set_union(ops);
+  }
+
+  // Remove those extracted ops in the original function.
+  removeExtractedOps(opsToRemove);
+}
+
+namespace {
+
+class ExtractScopStmtPass
+    : public mlir::PassWrapper<ExtractScopStmtPass,
+                               OperationPass<mlir::FuncOp>> {
+  void runOnOperation() override {
+    mlir::FuncOp f = getOperation();
+    OpBuilder b(f.getContext());
+
+    extractScopStmt(f, b);
+  }
+};
+
+} // namespace
+
+void polymer::registerExtractScopStmtPass() {
+  PassRegistration<ExtractScopStmtPass>(
+      "extract-scop-stmt", "Extract SCoP statements into functions.");
+}

--- a/test/polymer-opt/ExtractScopStmt/load-store.mlir
+++ b/test/polymer-opt/ExtractScopStmt/load-store.mlir
@@ -17,15 +17,15 @@ func @load_store(%A: memref<?xf32>, %B: memref<?xf32>) {
 // CHECK-NEXT:   %[[C0:.*]] = constant 0 : index
 // CHECK-NEXT:   %[[DIM0:.*]] = dim %[[ARG0]], %[[C0]] : memref<?xf32>
 // CHECK-NEXT:   affine.for %[[ARG2:.*]] = 0 to %[[DIM0]] {
-// CHECK-NEXT:     call @S0(%[[ARG0]], %[[ARG2]], %[[ARG1]]) : (memref<?xf32>, index, memref<?xf32>) -> ()
+// CHECK-NEXT:     call @S0(%[[ARG1]], %[[ARG2]], %[[ARG0]]) : (memref<?xf32>, index, memref<?xf32>) -> ()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK: func @S0(%[[ARG0]]: memref<?xf32>, %[[ARG1]]: index, %[[ARG2]]: memref<?xf32>) {
-// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG0]][%[[ARG1]]] : memref<?xf32>
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG2]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
-// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG2]][%[[ARG1]]] : memref<?xf32>
+// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG0]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
@@ -57,24 +57,132 @@ func @load_multi_stores(%A: memref<?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf
 // CHECK-NEXT:   %[[DIM1:.*]] = dim %[[ARG1]], %[[CST1]] : memref<?x?xf32>
 // CHECK-NEXT:   affine.for %[[I:.*]] = 0 to %[[DIM0]] {
 // CHECK-NEXT:     affine.for %[[J:.*]] = 0 to %[[DIM1]] {
-// CHECK-NEXT:       call @S0(%[[ARG0]], %[[I]], %[[ARG1]], %[[J]]) : (memref<?xf32>, index, memref<?x?xf32>, index) -> ()
-// CHECK-NEXT:       call @S1(%[[ARG0]], %[[I]], %[[ARG2]], %[[J]]) : (memref<?xf32>, index, memref<?x?xf32>, index) -> ()
+// CHECK-NEXT:       call @S0(%[[ARG1]], %[[I]], %[[J]], %[[ARG0]]) : (memref<?x?xf32>, index, index, memref<?xf32>) -> ()
+// CHECK-NEXT:       call @S1(%[[ARG2]], %[[I]], %[[J]], %[[ARG0]]) : (memref<?x?xf32>, index, index, memref<?xf32>) -> ()
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?x?xf32>, %[[ARG3:.*]]: index) {
-// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG0]][%[[ARG1]]] : memref<?xf32>
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?x?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index, %[[ARG3:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG3]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
-// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG2]][%[[ARG1]], %[[ARG3]]] : memref<?x?xf32>
+// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG0]][%[[ARG1]], %[[ARG2]]] : memref<?x?xf32>
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK: func @S1(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?x?xf32>, %[[ARG3:.*]]: index) {
-// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG0]][%[[ARG1]]] : memref<?xf32>
+// CHECK: func @S1(%[[ARG0:.*]]: memref<?x?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index, %[[ARG3:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG3]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
 // CHECK-NEXT:   %[[VAL2:.*]] = addf %[[VAL0]], %[[VAL1]] : f32
-// CHECK-NEXT:   affine.store %[[VAL2]], %[[ARG2]][%[[ARG1]], %[[ARG3]]] : memref<?x?xf32>
+// CHECK-NEXT:   affine.store %[[VAL2]], %[[ARG0]][%[[ARG1]], %[[ARG2]]] : memref<?x?xf32>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// -----
+
+// multiple functions
+
+func @f1(%A: memref<?xf32>, %B: memref<?xf32>) {
+  %c0 = constant 0 : index
+  %N = dim %A, %c0 : memref<?xf32> 
+
+  affine.for %i = 0 to %N {
+    %0 = affine.load %A[%i] : memref<?xf32>
+    %1 = mulf %0, %0 : f32
+    affine.store %1, %B[%i] : memref<?xf32>
+  }
+
+  return
+}
+
+func @f2(%A: memref<?xf32>, %B: memref<?xf32>) {
+  %c0 = constant 0 : index
+  %N = dim %A, %c0 : memref<?xf32> 
+
+  affine.for %i = 0 to %N {
+    %0 = affine.load %A[%i] : memref<?xf32>
+    %1 = addf %0, %0 : f32
+    affine.store %1, %B[%i] : memref<?xf32>
+  }
+
+  return
+}
+
+// CHECK: func @S0
+// CHECK: func @S1
+
+// -----
+
+// Alloc and alloca ops in the code.
+
+func @alloc_and_alloca() {
+  %A = alloc() : memref<32xf32>
+  %B = alloca() : memref<32xf32>
+
+  affine.for %i = 0 to 32 {
+    %0 = affine.load %A[%i] : memref<32xf32>
+    %1 = mulf %0, %0 : f32
+    affine.store %1, %B[%i] : memref<32xf32>
+  }
+
+  return
+}
+
+// CHECK: func @alloc_and_alloca() {
+// CHECK-NEXT:   %[[VAL0]] = alloc() : memref<32xf32>
+// CHECK-NEXT:   %[[VAL1]] = alloca() : memref<32xf32>
+// CHECK-NEXT:   affine.for %[[ARG0:.*]] = 0 to 32 {
+// CHECK-NEXT:     call @S0(%[[ARG0]], %[[VAL1]], %[[VAL0]]) : (index, memref<32xf32>, memref<32xf32>) -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+// CHECK: func @S0(%[[ARG0:.*]]: index, %[[ARG1:.*]]: memref<32xf32>, %[[ARG2:.*]]: memref<32xf32>) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG2]][%[[ARG0]]] : memref<32xf32>
+// CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
+// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG1]][%[[ARG0]]] : memref<32xf32>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// -----
+
+// This pass should not crash if there is no write op in the function.
+
+func @no_write() {
+  return
+}
+
+// CHECK: func @no_write() {
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// -----
+
+// Storing constants.
+
+func @write_const(%A: memref<?xf32>) {
+  %i = constant 0 : index
+  %j = constant 1 : index
+  %cst = constant 3.217 : f32
+  affine.store %cst, %A[%i] : memref<?xf32>
+  affine.store %cst, %A[%j] : memref<?xf32>
+  return
+}
+
+// CHECK: func @write_const(%[[ARG0:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   call @S0(%[[ARG0]]) : (memref<?xf32>) -> ()
+// CHECK-NEXT:   call @S1(%[[ARG0]]) : (memref<?xf32>) -> ()
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[CST:.*]] = constant 3.217000e+00 : f32
+// CHECK-NEXT:   %[[C0:.*]] = constant 0 : index
+// CHECK-NEXT:   affine.store %[[CST]], %[[ARG0]][%[[C0]]] : memref<?xf32>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+// CHECK: func @S1(%[[ARG0:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[CST:.*]] = constant 3.217000e+00 : f32
+// CHECK-NEXT:   %[[C0:.*]] = constant 1 : index
+// CHECK-NEXT:   affine.store %[[CST]], %[[ARG0]][%[[C0]]] : memref<?xf32>
 // CHECK-NEXT:   return
 // CHECK-NEXT: }

--- a/test/polymer-opt/ExtractScopStmt/load-store.mlir
+++ b/test/polymer-opt/ExtractScopStmt/load-store.mlir
@@ -22,7 +22,7 @@ func @load_store(%A: memref<?xf32>, %B: memref<?xf32>) {
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?xf32>) {
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?xf32>) attributes {scop.stmt} {
 // CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG2]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
 // CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG0]][%[[ARG1]]] : memref<?xf32>
@@ -64,14 +64,14 @@ func @load_multi_stores(%A: memref<?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK: func @S0(%[[ARG0:.*]]: memref<?x?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index, %[[ARG3:.*]]: memref<?xf32>) {
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?x?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index, %[[ARG3:.*]]: memref<?xf32>) attributes {scop.stmt} {
 // CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG3]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
 // CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG0]][%[[ARG1]], %[[ARG2]]] : memref<?x?xf32>
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK: func @S1(%[[ARG0:.*]]: memref<?x?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index, %[[ARG3:.*]]: memref<?xf32>) {
+// CHECK: func @S1(%[[ARG0:.*]]: memref<?x?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index, %[[ARG3:.*]]: memref<?xf32>) attributes {scop.stmt} {
 // CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG3]][%[[ARG1]]] : memref<?xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
 // CHECK-NEXT:   %[[VAL2:.*]] = addf %[[VAL0]], %[[VAL1]] : f32
@@ -137,7 +137,7 @@ func @alloc_and_alloca() {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
-// CHECK: func @S0(%[[ARG0:.*]]: index, %[[ARG1:.*]]: memref<32xf32>, %[[ARG2:.*]]: memref<32xf32>) {
+// CHECK: func @S0(%[[ARG0:.*]]: index, %[[ARG1:.*]]: memref<32xf32>, %[[ARG2:.*]]: memref<32xf32>) attributes {scop.stmt} {
 // CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG2]][%[[ARG0]]] : memref<32xf32>
 // CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
 // CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG1]][%[[ARG0]]] : memref<32xf32>
@@ -174,13 +174,13 @@ func @write_const(%A: memref<?xf32>) {
 // CHECK-NEXT:   call @S1(%[[ARG0]]) : (memref<?xf32>) -> ()
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
-// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>) {
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>) attributes {scop.stmt} {
 // CHECK-NEXT:   %[[CST:.*]] = constant 3.217000e+00 : f32
 // CHECK-NEXT:   %[[C0:.*]] = constant 0 : index
 // CHECK-NEXT:   affine.store %[[CST]], %[[ARG0]][%[[C0]]] : memref<?xf32>
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
-// CHECK: func @S1(%[[ARG0:.*]]: memref<?xf32>) {
+// CHECK: func @S1(%[[ARG0:.*]]: memref<?xf32>) attributes {scop.stmt} {
 // CHECK-NEXT:   %[[CST:.*]] = constant 3.217000e+00 : f32
 // CHECK-NEXT:   %[[C0:.*]] = constant 1 : index
 // CHECK-NEXT:   affine.store %[[CST]], %[[ARG0]][%[[C0]]] : memref<?xf32>

--- a/test/polymer-opt/ExtractScopStmt/load-store.mlir
+++ b/test/polymer-opt/ExtractScopStmt/load-store.mlir
@@ -1,0 +1,80 @@
+// RUN: polymer-opt %s -extract-scop-stmt -split-input-file | FileCheck %s
+
+func @load_store(%A: memref<?xf32>, %B: memref<?xf32>) {
+  %c0 = constant 0 : index
+  %N = dim %A, %c0 : memref<?xf32> 
+
+  affine.for %i = 0 to %N {
+    %0 = affine.load %A[%i] : memref<?xf32>
+    %1 = mulf %0, %0 : f32
+    affine.store %1, %B[%i] : memref<?xf32>
+  }
+
+  return
+}
+
+// CHECK: func @load_store(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[C0:.*]] = constant 0 : index
+// CHECK-NEXT:   %[[DIM0:.*]] = dim %[[ARG0]], %[[C0]] : memref<?xf32>
+// CHECK-NEXT:   affine.for %[[ARG2:.*]] = 0 to %[[DIM0]] {
+// CHECK-NEXT:     call @S0(%[[ARG0]], %[[ARG2]], %[[ARG1]]) : (memref<?xf32>, index, memref<?xf32>) -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// CHECK: func @S0(%[[ARG0]]: memref<?xf32>, %[[ARG1]]: index, %[[ARG2]]: memref<?xf32>) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG0]][%[[ARG1]]] : memref<?xf32>
+// CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
+// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG2]][%[[ARG1]]] : memref<?xf32>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// -----
+
+func @load_multi_stores(%A: memref<?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %N = dim %B, %c0 : memref<?x?xf32> 
+  %M = dim %B, %c1 : memref<?x?xf32> 
+
+  affine.for %i = 0 to %N {
+    affine.for %j = 0 to %M {
+      %0 = affine.load %A[%i] : memref<?xf32>
+      %1 = mulf %0, %0 : f32
+      affine.store %1, %B[%i, %j] : memref<?x?xf32>
+      %2 = addf %0, %1 : f32
+      affine.store %2, %C[%i, %j] : memref<?x?xf32>
+    }
+  }
+
+  return
+}
+
+// CHECK: func @load_multi_stores(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: memref<?x?xf32>, %[[ARG2:.*]]: memref<?x?xf32>) {
+// CHECK-NEXT:   %[[CST0:.*]] = constant 0 : index
+// CHECK-NEXT:   %[[CST1:.*]] = constant 1 : index
+// CHECK-NEXT:   %[[DIM0:.*]] = dim %[[ARG1]], %[[CST0]] : memref<?x?xf32>
+// CHECK-NEXT:   %[[DIM1:.*]] = dim %[[ARG1]], %[[CST1]] : memref<?x?xf32>
+// CHECK-NEXT:   affine.for %[[I:.*]] = 0 to %[[DIM0]] {
+// CHECK-NEXT:     affine.for %[[J:.*]] = 0 to %[[DIM1]] {
+// CHECK-NEXT:       call @S0(%[[ARG0]], %[[I]], %[[ARG1]], %[[J]]) : (memref<?xf32>, index, memref<?x?xf32>, index) -> ()
+// CHECK-NEXT:       call @S1(%[[ARG0]], %[[I]], %[[ARG2]], %[[J]]) : (memref<?xf32>, index, memref<?x?xf32>, index) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// CHECK: func @S0(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?x?xf32>, %[[ARG3:.*]]: index) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG0]][%[[ARG1]]] : memref<?xf32>
+// CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
+// CHECK-NEXT:   affine.store %[[VAL1]], %[[ARG2]][%[[ARG1]], %[[ARG3]]] : memref<?x?xf32>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+
+// CHECK: func @S1(%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: index, %[[ARG2:.*]]: memref<?x?xf32>, %[[ARG3:.*]]: index) {
+// CHECK-NEXT:   %[[VAL0:.*]] = affine.load %[[ARG0]][%[[ARG1]]] : memref<?xf32>
+// CHECK-NEXT:   %[[VAL1:.*]] = mulf %[[VAL0]], %[[VAL0]] : f32
+// CHECK-NEXT:   %[[VAL2:.*]] = addf %[[VAL0]], %[[VAL1]] : f32
+// CHECK-NEXT:   affine.store %[[VAL2]], %[[ARG2]][%[[ARG1]], %[[ARG3]]] : memref<?x?xf32>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }

--- a/tools/polymer-opt/polymer-opt.cc
+++ b/tools/polymer-opt/polymer-opt.cc
@@ -5,6 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "polymer/Transforms/ExtractScopStmt.h"
 #include "polymer/Transforms/InvariantScopTransform.h"
 #include "polymer/Transforms/PlutoTransform.h"
 
@@ -75,6 +76,7 @@ int main(int argc, char *argv[]) {
   // Register polymer specific passes.
   polymer::registerInvariantScopTransformPass();
   polymer::registerPlutoTransformPass();
+  polymer::registerExtractScopStmtPass();
 
   // Register any pass manager command line options.
   registerMLIRContextCLOptions();


### PR DESCRIPTION
This PR adds a new pass `-extract-scop-stmt`, which will be used to discover scop statements in the input code and turn them into function calls. This will be handy when translating MLIR to/from OpenScop.

A use case:

```mlir
func @load_multi_stores(%A: memref<?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
  %c0 = constant 0 : index
  %c1 = constant 1 : index
  %N = dim %B, %c0 : memref<?x?xf32> 
  %M = dim %B, %c1 : memref<?x?xf32> 

  affine.for %i = 0 to %N {
    affine.for %j = 0 to %M {
      %0 = affine.load %A[%i] : memref<?xf32>
      %1 = mulf %0, %0 : f32
      affine.store %1, %B[%i, %j] : memref<?x?xf32>
      %2 = addf %0, %1 : f32
      affine.store %2, %C[%i, %j] : memref<?x?xf32>
    }
  }

  return
}
```

Result: 

```mlir
  func @load_multi_stores(%arg0: memref<?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32>) {
    %c0 = constant 0 : index
    %c1 = constant 1 : index
    %0 = dim %arg1, %c0 : memref<?x?xf32>
    %1 = dim %arg1, %c1 : memref<?x?xf32>
    affine.for %arg3 = 0 to %0 {
      affine.for %arg4 = 0 to %1 {
        call @S0(%arg0, %arg3, %arg1, %arg4) : (memref<?xf32>, index, memref<?x?xf32>, index) -> ()
        call @S1(%arg0, %arg3, %arg2, %arg4) : (memref<?xf32>, index, memref<?x?xf32>, index) -> ()
      }
    }
    return
  }
  func @S0(%arg0: memref<?xf32>, %arg1: index, %arg2: memref<?x?xf32>, %arg3: index) {
    %0 = affine.load %arg0[%arg1] : memref<?xf32>
    %1 = mulf %0, %0 : f32
    affine.store %1, %arg2[%arg1, %arg3] : memref<?x?xf32>
    return
  }
  func @S1(%arg0: memref<?xf32>, %arg1: index, %arg2: memref<?x?xf32>, %arg3: index) {
    %0 = affine.load %arg0[%arg1] : memref<?xf32>
    %1 = mulf %0, %0 : f32
    %2 = addf %0, %1 : f32
    affine.store %2, %arg2[%arg1, %arg3] : memref<?x?xf32>
    return
  }
```