### PR TITLE
[Pass][ExtractScopStmt] internal index_cast

### DIFF
--- a/lib/Transforms/ExtractScopStmt.cc
+++ b/lib/Transforms/ExtractScopStmt.cc
@@ -177,6 +177,7 @@ static void getScopStmtOps(Operation *writeOp,
 
   while (!worklist.empty()) {
     Operation *op = worklist.pop_back_val();
+    LLVM_DEBUG(dbgs() << "-- Working on: " << (*op) << '\n');
 
     // If op is already in another callee.
     if (!isa<mlir::ConstantOp>(op) && opToCallee[op] &&
@@ -208,7 +209,9 @@ static void getScopStmtOps(Operation *writeOp,
     // if we consume it in the callee, the AffineValueMap built for the accesses
     // that use this dim cannot relate it with the global context.
     if (isa<memref::AllocaOp, memref::AllocOp, memref::DimOp,
-            mlir::AffineApplyOp, mlir::IndexCastOp>(op)) {
+            mlir::AffineApplyOp>(op) ||
+        (isa<mlir::IndexCastOp>(op) &&
+         op->getOperand(0).isa<BlockArgument>())) {
       for (mlir::Value result : op->getResults())
         args.insert(result);
       continue;
@@ -485,5 +488,6 @@ void polymer::registerExtractScopStmtPass() {
       "extract-scop-stmt", "Extract SCoP statements into functions.",
       [](OpPassManager &pm) {
         pm.addPass(std::make_unique<ExtractScopStmtPass>());
+        pm.addPass(createCanonicalizerPass());
       });
 }

--- a/test/polymer-opt/ExtractScopStmt/internal-index-cast.mlir
+++ b/test/polymer-opt/ExtractScopStmt/internal-index-cast.mlir
@@ -1,0 +1,34 @@
+// RUN: polymer-opt %s -extract-scop-stmt | FileCheck %s
+
+func @foo(%A: memref<1024xi32>, %B: memref<1024x16xi32>) {
+  %c4_i32 = constant 4 : i32
+  %c15_i32 = constant 15 : i32
+
+  affine.for %i = 1 to 5 {
+    affine.for %j = 0 to 16 {
+      %1 = affine.load %A[%j * 4] : memref<1024xi32>
+      %2 = shift_right_signed %1, %c4_i32 : i32
+      %3 = index_cast %2 : i32 to index
+      %4 = and %1, %c15_i32 : i32
+      %5 = index_cast %4 : i32 to index
+      %6 = memref.load %B[%3, %5] : memref<1024x16xi32>
+      affine.store %6, %A[%j * 4] : memref<1024xi32>
+    }
+  }
+
+  return
+}
+
+// CHECK: func private @S0
+// CHECK: %{{.*}} = affine.load
+// CHECK-NEXT: %{{.*}} = shift_right_signed
+// CHECK-NEXT: %{{.*}} = index_cast
+// CHECK-NEXT: %{{.*}} = and
+// CHECK-NEXT: %{{.*}} = index_cast
+// CHECK-NEXT: %{{.*}} = memref.load
+// CHECK-NEXT: affine.store
+
+// CHECK: func @foo(%[[ARG0:.*]]: memref<1024xi32>, %[[ARG1:.*]]: memref<1024x16xi32>)
+// CHECK-NEXT: affine.for %[[I:.*]] = 1 to 5
+// CHECK-NEXT: affine.for %[[J:.*]] = 0 to 16
+// CHECK-NEXT: call @S0(%[[ARG0]], %[[J]], %[[ARG1]])


### PR DESCRIPTION
Previously we just assume that index_cast is always in the beginning of a function, converting BlockArguments. This input program shows an alternative use case that should be handled.